### PR TITLE
ActionWidget::Base becomes a SimpleDelegator

### DIFF
--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -12,5 +12,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.5.1"
 
-  gem.add_dependency 'smart_properties', '~> 1.1'
+  gem.add_dependency 'smart_properties', '~> 1.7'
 end

--- a/lib/action_widget/base.rb
+++ b/lib/action_widget/base.rb
@@ -1,31 +1,11 @@
-require 'smart_properties'
-
 module ActionWidget
-  class Base
+  class Base < SimpleDelegator
+    alias view __getobj__
     include SmartProperties
-
-    def initialize(view, *args)
-      @view = view
-      super(*args)
-    end
 
     def render
       raise NotImplementedError, "#{self.class} must implement #render"
     end
-
-    protected
-
-      attr_reader :view
-
-      undef :capture if method_defined?(:capture)
-
-      def method_missing(method, *args, &block)
-        view.send(method, *args, &block)
-      rescue NoMethodError
-        # Double check - the NoMethodError might have occurred somewhere else.
-        view.respond_to?(method) ? raise : super
-      end
-
   end
 end
 


### PR DESCRIPTION
This simplification is possible because SmartProperties supports positional argument forwarding for #initialize since version 1.7