### PR TITLE
Fixes ActionWidget::Base#initialize and vastly improves test coverage

### DIFF
--- a/lib/action_widget/base.rb
+++ b/lib/action_widget/base.rb
@@ -6,12 +6,11 @@ module ActionWidget
     attr_reader :options
 
     def initialize(view, attributes = {})
-      attributes = attributes.dup
       properties = self.class.properties
+      attributes, options = attributes.partition { |name, value| properties.key?(name) }
 
-      @options = attributes.delete_if { |name, value| properties.key?(name) }
-
-      super(view, attributes)
+      @options = Hash[options]
+      super(view, Hash[attributes])
     end
 
     def render

--- a/spec/action_widget_spec.rb
+++ b/spec/action_widget_spec.rb
@@ -1,23 +1,47 @@
 require 'spec_helper'
 
-RSpec.describe ActionWidget::Base do
-  let(:view) { ActionView::Base.new }
+class DummyWidget < ActionWidget::Base
+  property :type
 
-  subject(:dummy_widget) do
-    Class.new(described_class) do
-      def render
-        tag(:br, class: options[:class])
-      end
+  def render(content = nil)
+    classes = [options[:class], type].compact
+    if classes.empty?
+      content_tag(:p, content)
+    else
+      content_tag(:p, content, class: classes)
     end
   end
+end
+
+class ViewContext < ActionView::Base
+  include ActionWidget::ViewHelper
+end
+
+RSpec.describe DummyWidget do
+  let(:view) { ViewContext.new }
 
   it "should delegate unknown method calls to the view context" do
-    expect(dummy_widget.new(view).render).to eq("<br />")
+    expect(described_class.new(view).render).to eq("<p></p>")
   end
 
-  it "should should capture all keyword arguments that do not belong to a property in an options hash" do
-    instance = dummy_widget.new(view, class: 'wide')
-    expect(instance.options).to eq({class: 'wide'})
-    expect(instance.render).to eq('<br class="wide" />')
+  context "option capturing and positional argument forwarding" do
+    let(:expected_html) { '<p class="wide teaser">Hello World</p>' }
+
+    it "should be possible to reference a property using a symbol" do
+      attributes = {type: 'teaser', class: 'wide'}
+      expect(view.dummy_widget("Hello World", attributes)).to eq(expected_html)
+    end
+
+    it "should be possible to reference a property using a string" do
+      pending "Requires a newer version of smart_properties: v1.10+"
+
+      attributes = {"type" => 'teaser', class: 'wide'}
+      expect(view.dummy_widget("Hello World", attributes)).to eq(expected_html)
+    end
+
+    specify "keyword arguments that do not correspond to a property should be captured as options" do
+      instance = described_class.new(view, class: 'wide')
+      expect(instance.options).to eq({class: 'wide'})
+    end
   end
 end


### PR DESCRIPTION
The previous tests were unable to discover that option capturing and positional argument forwarding was actually broken. The new tests excercise the autogenerated helper files to guarantee full coverage.

Fixes #11.