### PR TITLE
New version requirement for SmartProperties: v1.10

### DIFF
--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = "0.5.1"
 
-  gem.add_dependency 'smart_properties', '~> 1.7'
+  gem.add_dependency 'smart_properties', '~> 1.10'
 
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3.3'

--- a/spec/action_widget_spec.rb
+++ b/spec/action_widget_spec.rb
@@ -33,8 +33,6 @@ RSpec.describe DummyWidget do
     end
 
     it "should be possible to reference a property using a string" do
-      pending "Requires a newer version of smart_properties: v1.10+"
-
       attributes = {"type" => 'teaser', class: 'wide'}
       expect(view.dummy_widget("Hello World", attributes)).to eq(expected_html)
     end


### PR DESCRIPTION
This version of SmartProperties plays nice with hashes that use strings
as keys.