### PR TITLE
ActionWidget::ViewHelper - Improved widget lookup

### DIFF
--- a/lib/action_widget.rb
+++ b/lib/action_widget.rb
@@ -20,6 +20,14 @@ module ActionWidget
   end
 
   class << self
+    def [](helper_name)
+      registry[helper_name]
+    end
+
+    def []=(helper_name, klass)
+      registry[helper_name] = klass
+    end
+
     def configuration
       @configuration ||= Configuration.new(suffix: "Widget")
     end
@@ -32,10 +40,27 @@ module ActionWidget
       !!configuration.pattern.match(name)
     end
 
-    def class_for(helper_name)
+    protected
+
+    def registry
+      @registry ||= Hash.new do |registry, helper_name|
+        if klass = find_action_widget(helper_name)
+          registry[helper_name] = klass
+        else
+          nil
+        end
+      end
+    end
+
+    private
+
+    def find_action_widget(helper_name)
+      return nil unless helper?(helper_name)
       basename = configuration.pattern.match(helper_name)[1]
       classname = [configuration.prefix, basename.camelcase, configuration.suffix].join("")
       classname.constantize
+    rescue NameError, LoadError
+      nil
     end
   end
 end

--- a/lib/action_widget/view_helper.rb
+++ b/lib/action_widget/view_helper.rb
@@ -1,24 +1,21 @@
 module ActionWidget
   module ViewHelper
-
     def method_missing(name, *args, &block)
-      return super unless ActionWidget.helper?(name)
-
-      klass = begin
-        ActionWidget.class_for(name)
-      rescue NameError, LoadError
-        return super
-      end
+      widget = ActionWidget[name]
+      return super if widget.nil?
 
       ActionWidget::ViewHelper.module_eval <<-RUBY
         def #{name}(*args, &block)                          # def example_widget(*args, &block)
           attrs = args.last.kind_of?(Hash) ? args.pop : {}
-          #{klass}.new(self, attrs).render(*args, &block)   #   ExampleWidget.new(self, attrs).render(*args, &block)
+          #{widget}.new(self, attrs).render(*args, &block)  #   ExampleWidget.new(self, attrs).render(*args, &block)
         end                                                 # end
       RUBY
 
       send(name, *args, &block)
     end
 
+    def respond_to_missing?(name, include_private = false)
+      !!ActionWidget[name] || super
+    end
   end
 end

--- a/spec/action_widget_spec.rb
+++ b/spec/action_widget_spec.rb
@@ -17,6 +17,13 @@ class ViewContext < ActionView::Base
   include ActionWidget::ViewHelper
 end
 
+RSpec.describe ViewContext do
+  subject(:view_context) { described_class.new }
+  it 'should implement #respond_to_missing?' do
+    expect(view_context.send(:respond_to_missing?, :dummy_widget)).to eq(true)
+  end
+end
+
 RSpec.describe DummyWidget do
   let(:view) { ViewContext.new }
 


### PR DESCRIPTION
Implements `ActionWidget::ViewHelper#respond_to_missing?` and improves the implementation of `ActionWidget::ViewHelper#method_missing`.  `ActionWidget` now has a registry to keep track of all widget classes.