### PR TITLE
ActionWidget::Base.render convenience method

### DIFF
--- a/lib/action_widget/base.rb
+++ b/lib/action_widget/base.rb
@@ -5,6 +5,11 @@ module ActionWidget
 
     attr_reader :options
 
+    def self.render(view, *args, &block)
+      attrs = args.last.kind_of?(Hash) ? args.pop : {}
+      self.new(view, attrs).render(*args, &block)
+    end
+
     def initialize(view, attributes = {})
       properties = self.class.properties
       attributes, options = attributes.partition { |name, value| properties.key?(name) }

--- a/lib/action_widget/view_helper.rb
+++ b/lib/action_widget/view_helper.rb
@@ -5,10 +5,9 @@ module ActionWidget
       return super if widget.nil?
 
       ActionWidget::ViewHelper.module_eval <<-RUBY
-        def #{name}(*args, &block)                          # def example_widget(*args, &block)
-          attrs = args.last.kind_of?(Hash) ? args.pop : {}
-          #{widget}.new(self, attrs).render(*args, &block)  #   ExampleWidget.new(self, attrs).render(*args, &block)
-        end                                                 # end
+        def #{name}(*args, &block)               # def example_widget(*args, &block)
+          #{widget}.render(self, *args, &block)  #   ExampleWidget.render(self, *args, &block)
+        end                                      # end
       RUBY
 
       send(name, *args, &block)


### PR DESCRIPTION
Auto-generated helpers now simply call `<Widget>.render`. By default this method forwards all positional arguments to the `#render` method and all keyword arguemtents to the initializer. The benefit of this method is twofold: it simplifies the code for the auto-generated methods and it allows to customize the rendering behaviour of a component by overriding the class method. For example, redirecting specific positional arguments to the constructor is now possible.