### PR TITLE
Ruby 3 compatibility

### DIFF
--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -14,11 +14,13 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
   gem.version       = ActionWidget::VERSION
 
-  gem.add_dependency 'smart_properties', '~> 1.10'
-  gem.add_dependency 'activesupport', '> 2.2'
+  gem.required_ruby_version = '>= 3.0.0'
+
+  gem.add_dependency 'smart_properties', '~> 1.17'
+  gem.add_dependency 'activesupport', '> 6.1'
 
   gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'rake', '~> 10.0'
-  gem.add_development_dependency 'rspec', '~> 3.3'
-  gem.add_development_dependency 'actionview', '~> 4.0'
+  gem.add_development_dependency 'rake', '~> 13.0'
+  gem.add_development_dependency 'rspec', '~> 3.12'
+  gem.add_development_dependency 'actionview', '~> 7.0'
 end

--- a/lib/action_widget/base.rb
+++ b/lib/action_widget/base.rb
@@ -7,12 +7,12 @@ module ActionWidget
 
     def self.render(view, *args, &block)
       attrs = args.last.kind_of?(Hash) ? args.pop : {}
-      self.new(view, attrs).render(*args, &block)
+      self.new(view, **attrs).render(*args, &block)
     end
 
-    def initialize(view, attributes = {})
+    def initialize(view, **kwargs)
       properties = self.class.properties
-      attributes, options = attributes.partition { |name, value| properties.key?(name) }
+      attributes, options = kwargs.partition { |name, value| properties.key?(name) }
 
       @options = Hash[options]
       super(view, Hash[attributes])
@@ -23,4 +23,3 @@ module ActionWidget
     end
   end
 end
-

--- a/spec/action_widget_spec.rb
+++ b/spec/action_widget_spec.rb
@@ -18,14 +18,14 @@ class ViewContext < ActionView::Base
 end
 
 RSpec.describe ViewContext do
-  subject(:view_context) { described_class.new }
+  subject(:view_context) { described_class.empty }
   it 'should implement #respond_to_missing?' do
     expect(view_context.send(:respond_to_missing?, :dummy_widget)).to eq(true)
   end
 end
 
 RSpec.describe DummyWidget do
-  let(:view) { ViewContext.new }
+  let(:view) { ViewContext.empty }
 
   it "should delegate unknown method calls to the view context" do
     expect(described_class.new(view).render).to eq("<p></p>")


### PR DESCRIPTION
This PR updates the dependencies in the gemspec and makes some minor adjustments to the code and specs to allow utilizing `action_widget` in newer Ruby/Rails versions (esp. ruby >= 3).