### PR TITLE
Rails 7 and 8 support

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -1,0 +1,26 @@
+name: Testing
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Ruby v${{ matrix.ruby_version}}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby_version: [3.4.1]
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby_version }}
+      - name: Install dependencies
+        run: bundle install
+      - name: Run tests
+        run: bundle exec rake spec

--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -1,24 +1,27 @@
-# -*- encoding: utf-8 -*-
-require File.expand_path('../lib/action_widget/version.rb', __FILE__)
+# frozen_string_literal: true
+
+require File.expand_path('lib/action_widget/version.rb', __dir__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Konstantin Tennhard"]
-  gem.email         = ["me@t6d.de"]
-  gem.summary       = %q{Reusable view components for your Ruby web application}
-  gem.homepage      = "http://github.com/t6d/action_widget"
+  gem.authors               = ['Konstantin Tennhard']
+  gem.email                 = ['me@t6d.de']
+  gem.summary               = 'Reusable view components for your Ruby web application'
+  gem.homepage              = 'http://github.com/t6d/action_widget'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
-  gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "action_widget"
-  gem.require_paths = ["lib"]
-  gem.version       = ActionWidget::VERSION
+  gem.files                 = `git ls-files`.split($\)
+  gem.executables           = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
+  gem.test_files            = gem.files.grep(%r{^(test|spec|features)/})
+  gem.name                  = 'action_widget'
+  gem.require_paths         = ['lib']
+  gem.version               = ActionWidget::VERSION
+  gem.required_ruby_version = '>= 2.7.0'
 
-  gem.add_dependency 'smart_properties', '~> 1.10'
   gem.add_dependency 'activesupport', '> 2.2'
+  gem.add_dependency 'smart_properties', '~> 1.10'
 
+  gem.add_development_dependency 'actionview', '>= 6.0'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.3'
-  gem.add_development_dependency 'actionview', '>= 6.0'
+  gem.add_development_dependency 'ruby-lsp'
 end

--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -22,6 +22,10 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'actionview', '>= 6.0'
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake'
-  gem.add_development_dependency 'rspec', '~> 3.3'
+  gem.add_development_dependency 'rspec', '~> 3.13'
   gem.add_development_dependency 'ruby-lsp'
+  gem.add_development_dependency 'ostruct'
+  gem.add_development_dependency 'mutex_m'
+  gem.add_development_dependency 'base64'
+  gem.add_development_dependency 'bigdecimal'
 end

--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'activesupport', '> 2.2'
 
   gem.add_development_dependency 'pry'
-  gem.add_development_dependency 'rake', '~> 10.0'
+  gem.add_development_dependency 'rake'
   gem.add_development_dependency 'rspec', '~> 3.3'
   gem.add_development_dependency 'actionview', '>= 6.0'
 end

--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -20,5 +20,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency 'pry'
   gem.add_development_dependency 'rake', '~> 10.0'
   gem.add_development_dependency 'rspec', '~> 3.3'
-  gem.add_development_dependency 'actionview', '~> 4.0'
+  gem.add_development_dependency 'actionview', '>= 6.0'
 end

--- a/lib/action_widget/configuration.rb
+++ b/lib/action_widget/configuration.rb
@@ -4,7 +4,7 @@ module ActionWidget
     property :prefix
     property :suffix
     property :superclass, required: true, default: -> { ActionWidget::Base }
-    property :directory, required: true, converts: :to_s, accepts: ->(string) { !string.empty? }, default: -> { [underscored_prefix, underscored_suffix].compact.join("_") }
+    property :directory, required: true, converts: :to_s, accepts: ->(string) { !string.empty? }, default: -> { [underscored_prefix, underscored_suffix].compact.join("_").pluralize }
     property :minitest_superclass
 
     attr_reader :pattern

--- a/lib/action_widget/extensions/rails/railtie.rb
+++ b/lib/action_widget/extensions/rails/railtie.rb
@@ -5,7 +5,9 @@ module ActionWidget
     module Rails
       class Railtie < ::Rails::Railtie
         initializer "action_widget.helper" do
-          ActionView::Base.send(:include, ::ActionWidget::ViewHelper)
+          ActiveSupport.on_load(:action_view) do
+            include  ActionWidget::ViewHelper
+          end
         end
       end
     end

--- a/spec/action_widget_spec.rb
+++ b/spec/action_widget_spec.rb
@@ -18,14 +18,14 @@ class ViewContext < ActionView::Base
 end
 
 RSpec.describe ViewContext do
-  subject(:view_context) { described_class.new }
+  subject(:view_context) { described_class.empty }
   it 'should implement #respond_to_missing?' do
     expect(view_context.send(:respond_to_missing?, :dummy_widget)).to eq(true)
   end
 end
 
 RSpec.describe DummyWidget do
-  let(:view) { ViewContext.new }
+  let(:view) { ViewContext.empty }
 
   it "should delegate unknown method calls to the view context" do
     expect(described_class.new(view).render).to eq("<p></p>")


### PR DESCRIPTION
- Modernizes the mechansim that is used for loading the ViewHelper
- Changes the default directory from app/widget to app/widgets
- Ensure Ruby 3.4 compatibility
- Switches the testing setup from Buildkite to Github Actions

