### PR TITLE
Update gemspec to require Ruby 3.0 and Activesupport > 6.0

### DIFF
--- a/action_widget.gemspec
+++ b/action_widget.gemspec
@@ -14,9 +14,9 @@ Gem::Specification.new do |gem|
   gem.name                  = 'action_widget'
   gem.require_paths         = ['lib']
   gem.version               = ActionWidget::VERSION
-  gem.required_ruby_version = '>= 2.7.0'
+  gem.required_ruby_version = '>= 3.0.0'
 
-  gem.add_dependency 'activesupport', '> 2.2'
+  gem.add_dependency 'activesupport', '> 6.0'
   gem.add_dependency 'smart_properties', '~> 1.10'
 
   gem.add_development_dependency 'actionview', '>= 6.0'


### PR DESCRIPTION
Raise the minimum required Ruby version to 3.0 to ensure compatibility with the latest features and deprecations. Update Activesupport dependency to version > 6.0 to align with modern framework standards.
